### PR TITLE
Fixed parenthesis on initialization

### DIFF
--- a/logistic_regression_train.py
+++ b/logistic_regression_train.py
@@ -91,13 +91,13 @@ yGold = tf.placeholder(tf.float32, [None, numLabels])
 
 weights = tf.Variable(tf.random_normal([numFeatures,numLabels],
                                        mean=0,
-                                       stddev=(np.sqrt(6/numFeatures+
-                                                         numLabels+1)),
+                                       stddev=(np.sqrt(6/(numFeatures+
+                                                         numLabels+1))),
                                        name="weights"))
 
 bias = tf.Variable(tf.random_normal([1,numLabels],
                                     mean=0,
-                                    stddev=(np.sqrt(6/numFeatures+numLabels+1)),
+                                    stddev=(np.sqrt(6/(numFeatures+numLabels+1))),
                                     name="bias"))
 
 


### PR DESCRIPTION
Parenthesis were missing on the equation sqrt(6/(numFeatures + numLabels)) meaning that the equation was evaluated incorrectly  due to order of operations